### PR TITLE
Async Await Refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,21 @@
 language: node_js
 node_js:
-  - "stable"
+- stable
 cache:
   directories:
-    - "node_modules"
+  - node_modules
 services:
-  - postgresql
-
+- postgresql
 before_install:
 - npm update
 install:
 - npm install
 script:
 - npm test
-
 before_script:
-  - psql -c 'create database sweater_weather_test;' -U postgres
-  - knex migrate:latest --env test
+- psql -c 'create database sweater_weather_test;' -U postgres
+- knex migrate:latest --env test
+env:
+  global:
+  - secure: XkhnsSTQnAttRtlXDndWSY8JsARfQXlXxIWy7FzXJ/5BOQWIWw5R6fuo4A80w23NDX6vfqKFhBkBnfQzCoHV96HmDN7hQP0AmcqA6bfDBDg75veLGQ4NOVsabmA2vL26x3Xq+Y6u3B5uPRF2AGXR4FjG8jOGgFxLsrtsYllz1za3LmfDW4YiREaXIrpMVNpS39c0z2Dwt3Bpy4wFNNc7VdNvdLVtqf5rwS39HxiurHT8IzyNWJ9eWbVKkTzBWS2t4UX+wOwIDPfSTlKWoYgm4Fa/YK/gg366vyJKRar/3MSiEKjcaVMwMn9jgSlZY+PpuE7Hlukf4/zgkhPgOEWP8XhfidqZCwpAyw5ONHR7l0CK07301j6fY63t8+YPIo0hSvFBjTl5wpB2WQH6GIt9X7fqV1ybD+nLRrtE4uLXgD7nSdO+qo7CqpyCAA9eTM+Y2ncfS43KaLoRGucBWceiN2MQCgePEEeAWtou7bYr7aSTILKpx33qByPp8JxGUgde4EjfGJVaQP0zSopDv4Bc4pz1YAOuqS+H6UUe7lFJv+a3E85nPV8jCAAo8JMD/nzeePkhYXGlljTRHnIn+YWVZYJtjsdQLZdvY45dQgiTPwAFsEEGmHAZjY/Oi6OhYcx8NV+Jleuxyc9nZ2uQfAvbWYwqqiF24ktpEfQCuypjRMs=
+  - secure: JAWa5/gV+Ohc+nD3euvpSc2F5d+CichI3A7A7GfmYzdGc5TIuPt6AW60lac1jyJy2fVoww2kL3E4WK2/ey67TZr1xYvCUJKKVpp8G+R10/e8bypzjBXhlnrz/QUy9HpdgkPs3US+Z37zW63x4sMwaN3eZDhpC5PlDthH8yYefOA2rCs2oGitxYdZVYM3xADXMrmEE24v9kLb7JJZNwtPWzeVl+iRwl1PYsY+huBYl4kfSJGmfgN/b/PJmIIqUnymCnct0wmYLUfthaxCJLT0YRFMN8C+yubK/imqKOENVVLtqN9R6QkPqpQ0TYQDk/mXfYcQf/KAAAphMb8oRyrwynahHw2ZFy40Bd2nO2jksWI7Mn87z0DS765NZccTeYYehLKDqaVSb9YZBZhlCqjLYQ2i716oFtsFf9dficNTQ7upn+LXgwmhWDqKdGuuju/BdCUeF+mVXiWpv0MWSR/Y4VOBvI9ao+E23Bge9Ks9vbB72oIlVOKBdHVh9RqNmr4xatOpX1QCLXoBQhpKk3Skv6uvEWAALRCfLgeHsjyNMMfsvuz4mjQ5AeEZDIA/qqXNpgyAGlLA14fD/bTCzoPvlEhF8a7qe60ppJVnhwIOF+4G6e2mtUMq1KIB3mxxsBaC34sEDwAodwKN+/B23aXmj84fS9o6gK8iIBSZZU6fWic=

--- a/tests/addFavorites.spec.js
+++ b/tests/addFavorites.spec.js
@@ -1,0 +1,31 @@
+var request = require('supertest');
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+describe('New favorites api endpoint', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table users cascade');
+    await database.raw('truncate table locations cascade');
+
+    let user = { name: 'Agnes', api_key: '12345'}
+    await database('users').insert(user);
+  });
+
+  afterEach(async () => {
+    await database.raw('truncate table users cascade');
+    await database.raw('truncate table locations cascade');
+  });
+
+  test('It can create a new favorite with api key and location', async () => {
+    const res = await request(app)
+      .post('/api/v1/favorites')
+      .send({api_key: '12345', location: 'sevilla, spain'})
+      .type('form');
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.message).toBe('Seville, Spain has been added to your favorites');
+  });
+});

--- a/tests/addFavorites.spec.js
+++ b/tests/addFavorites.spec.js
@@ -28,4 +28,50 @@ describe('New favorites api endpoint', () => {
     expect(res.statusCode).toBe(200);
     expect(res.body.message).toBe('Seville, Spain has been added to your favorites');
   });
+
+  test('It sees an error message if api key is missing', async () => {
+    const res = await request(app)
+      .post('/api/v1/favorites')
+      .send({location: 'sevilla, spain'})
+      .type('form');
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body.status).toBe(401);
+    expect(res.body.message).toBe('Missing or invalid API key. Please try again.')
+  });
+
+  test('It sees an error message if api key is invalid', async () => {
+    const res = await request(app)
+      .post('/api/v1/favorites')
+      .send({api_key: 'sg2o3u4thrkjng9842', location: 'sevilla, spain'})
+      .type('form');
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body.status).toBe(401);
+    expect(res.body.message).toBe('Missing or invalid API key. Please try again.')
+  });
+
+  test('It sees an error if the location is missing', async () => {
+    const res = await request(app)
+      .post('/api/v1/favorites')
+      .send({api_key: '12345'})
+      .type('form');
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.status).toBe(400);
+      expect(res.body.message).toBe('Location not found. Please try again.')
+
+  });
+
+  test('It sees an error if the location is invalid', async () => {
+    const res = await request(app)
+      .post('/api/v1/favorites')
+      .send({api_key: '12345', location: 'sdkjglhaitgjkb'})
+      .type('form');
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.status).toBe(400);
+      expect(res.body.message).toBe('Location not found. Please try again.')
+
+  });
 });

--- a/tests/app_spec.js
+++ b/tests/app_spec.js
@@ -1,11 +1,9 @@
-var shell = require('shelljs');
-var request = require("supertest");
+var request = require('supertest');
 var app = require('../app');
 
 describe('Test the root path', () => {
   test('It should respond to the GET method', async () => {
-    const res = await request(app)
-      .get("/");
+    const res = await request(app).get('/');
 
     expect(res.statusCode).toBe(200);
   });


### PR DESCRIPTION
- Refactor new favorite location endpoint using async/await syntax
- Add happy and sad path testing for new favorite endpoint (invalid/missing api key and/or location)
- Overall test coverage is at 67%

I'm going to clean the router file up by creating a service object and moving the helper methods into a module. @rhantak do you see any other ways that the `router.post` method could be refactored?